### PR TITLE
Bugfix/label placement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+- Labels are now properly centered above the selected point. 
+- The label is properly shown if it overflows at the right side of the chart.
+
 ## 1.0.0
 - Change axisBuilders to Records with a Widget and an optional width
 - Labels are now always drawn at a position inside the chart

--- a/lib/src/chart/line_chart/painter.dart
+++ b/lib/src/chart/line_chart/painter.dart
@@ -401,10 +401,10 @@ class LineChartPainter extends CustomPainter {
     return (
       min(
         max(
-          point.dx - labelSpaceNeeded.$1 - labelPadding * 2,
+          point.dx - labelSpaceNeeded.$1 - labelPadding,
           distanceBetweenPointAndLabel / 2,
         ),
-        size.width - distanceBetweenPointAndLabel / 2,
+        size.width - (labelSpaceNeeded.$1 + labelPadding) * 2,
       ),
       point.dy - labelSpaceNeeded.$2 < 0
           ? point.dy + distanceBetweenPointAndLabel

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_chart
 description: Flutter Chart rendering library
-version: 1.0.0
+version: 1.0.1
 
 
 environment:


### PR DESCRIPTION
Closes: #4 

Label are now properly centered above the selected point and the label is properly shown if it overflows at the right side of the chart.